### PR TITLE
Standardize code replacement strings - Javascript

### DIFF
--- a/JavaScriptSPA/index.html
+++ b/JavaScriptSPA/index.html
@@ -20,7 +20,7 @@
     var msalConfig = {
         auth: {
             clientId: 'Enter_the_Application_Id_here', //This is your client ID
-            authority: "https://login.microsoftonline.com/Enter_the_Tenant_Info_Here" //This is your tenant info
+            authority: "https://login.microsoftonline.com/common" //This is your tenant info
         },
         cache: {
             cacheLocation: "localStorage",


### PR DESCRIPTION
We have a working prototype to improve developer experience in quickstarts so that the downloaded code sample is ready-to-run and no longer needs manual step of copy-pasting the code blob with clientId/password/etc info. For that, we're standardizing code replacement strings as follows:
ClientIdStringToReplace : "Enter_the_Application_Id_here"
TenantInfoToReplace: "common" 

Common works for all types of tenancy (single or multi) and can be used out of the box.