### PR TITLE
removing logout url from apps.json

### DIFF
--- a/AppCreationScripts/apps.json
+++ b/AppCreationScripts/apps.json
@@ -9,7 +9,6 @@
       "x-ms-id": "JavaScriptSpa",
       "x-ms-name": "active-directory-javascript-graphapi-v2",
       "x-ms-version": "2.0",
-      "logoutUrl": "http://localhost:3000/",
       "replyUrlsWithType": [
         {
           "url": "http://localhost:3000/",


### PR DESCRIPTION
This PR removes the logout url from apps.json which causes issues in portal-quickstart and was not in fact required for the sample to function.