### PR TITLE
Remove dependency "path"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "express": "^4.12.3",
     "morgan": "^1.5.2",
-    "path": "^0.11.14"
   },
   "devDependencies": {
     "nodemon": "^2.0.2"


### PR DESCRIPTION
"path" package is part of express.js now and need not be separately installed.